### PR TITLE
Bump version of checkout action

### DIFF
--- a/.github/workflows/bump-deps.yaml
+++ b/.github/workflows/bump-deps.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check-out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependency updates
         run: |

--- a/.github/workflows/generate-site.yml
+++ b/.github/workflows/generate-site.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check-out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This should get rid of the "Node.js 16 actions are deprecated" warnings in the jobs logs.