### PR TITLE
Attribution and duration for baseline blockage.

### DIFF
--- a/site/_includes/feature_short.njk
+++ b/site/_includes/feature_short.njk
@@ -6,6 +6,9 @@
   {% include "tags.njk" %}
   <p>{{ feature.description_html | safe }}</p>
   <p><strong><a href="/features/{{ feature.id | slugify }}/">Learn more</a></strong></p>
+  {%- if feature.blockedOn %}
+  <p>Wide availability blocked since {{ feature.blockedSince }} by {{ feature.blockedOnName }} ({{ feature.monthsBlocked }} months)</p>
+  {%- endif %}
 
   {% include "compat.njk" %}
 </div>

--- a/site/_includes/layout.njk
+++ b/site/_includes/layout.njk
@@ -22,7 +22,7 @@ siteTitle: Web features explorer
         <li class="nobaseline"><a href="/limited-availability">Limited availability</a></li>
         <li><a href="/all">All</a></li>
         <li><a href="/groups">Groups</a></li>
-        <!-- <li><a href="/missingone">Missing in just one engine</a></li> -->
+        <li class="nobaseline"><a href="/missingone">Missing in one engine</a></li>
       </ul>
     </nav>
 


### PR DESCRIPTION
Exposes the "missing in one" page in the top nav and augments the information in each item with the duration of baseline blockage.

Considered a small counter of features prevented from reaching baseline by each browser but didn't add. Might do in a follow-up if there's support.