### PR TITLE
Add MDN Links

### DIFF
--- a/mdnDocsOverrides.json
+++ b/mdnDocsOverrides.json
@@ -19,31 +19,45 @@
     "Web/CSS/abs",
     "Web/CSS/sign"
   ],
-  "absolute-positioning": [],
+  "absolute-positioning": [
+    "Web/CSS/position"
+  ],
   "accelerometer": [
     "Web/API/Accelerometer"
   ],
   "accent-color": [
     "Web/CSS/accent-color"
   ],
-  "active-view-transition": [],
+  "active-view-transition": [
+    "Web/CSS/::view-transition"
+  ],
   "address": [
     "Web/HTML/Element/address"
   ],
-  "alerts": [],
-  "align-content-block": [],
-  "alignment-baseline": [],
+  "alerts": [
+    "Web/API/Window/alert"
+  ],
+  "align-content-block": [
+    "Web/CSS/align-content"
+  ],
+  "alignment-baseline": [
+    "Web/SVG/Attribute/alignment-baseline"
+  ],
   "all": [
     "Web/CSS/all"
   ],
-  "alt-text-generated-content": [],
+  "alt-text-generated-content": [
+    "Web/CSS/content"
+  ],
   "alternative-style-sheets": [
     "Web/CSS/Alternative_style_sheets"
   ],
   "anchor-positioning": [
     "Web/CSS/CSS_anchor_positioning"
   ],
-  "angle-instanced-arrays": [],
+  "angle-instanced-arrays": [
+    "Web/API/ANGLE_instanced_arrays"
+  ],
   "animation-composition": [
     "Web/CSS/animation-composition"
   ],
@@ -89,8 +103,12 @@
     "Web/JavaScript/Reference/Global_Objects/Array/fill",
     "Web/JavaScript/Reference/Global_Objects/TypedArray/fill"
   ],
-  "array-find": [],
-  "array-findlast": [],
+  "array-find": [
+    "Web/JavaScript/Reference/Global_Objects/Array/find"
+  ],
+  "array-findlast": [
+    "Web/JavaScript/Reference/Global_Objects/Array/findLast"
+  ],
   "array-flat": [
     "Web/JavaScript/Reference/Global_Objects/Array/flat",
     "Web/JavaScript/Reference/Global_Objects/Array/flatMap"
@@ -113,8 +131,12 @@
   "array-isarray": [
     "Web/JavaScript/Reference/Global_Objects/Array/isArray"
   ],
-  "array-iteration-methods": [],
-  "array-iterators": [],
+  "array-iteration-methods": [
+    "Web/JavaScript/Reference/Global_Objects/Array"
+  ],
+  "array-iterators": [
+    "Web/JavaScript/Reference/Statements/for...of"
+  ],
   "array-of": [
     "Web/JavaScript/Reference/Global_Objects/Array/of",
     "Web/JavaScript/Reference/Global_Objects/TypedArray/of"
@@ -149,14 +171,18 @@
   "atomics-wait-async": [
     "Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync"
   ],
-  "attr": [],
+  "attr": [
+    "Web/CSS/attr"
+  ],
   "attr-contents": [
     "Web/CSS/attr"
   ],
   "audio": [
     "Web/HTML/Element/audio"
   ],
-  "audio-session": [],
+  "audio-session": [
+    "Web/API/Navigator"
+  ],
   "audio-video-tracks": [
     "Web/API/HTMLMediaElement/audioTracks",
     "Web/API/HTMLMediaElement/videoTracks"

--- a/mdnDocsOverrides.json
+++ b/mdnDocsOverrides.json
@@ -47,7 +47,7 @@
     "Web/CSS/all"
   ],
   "alt-text-generated-content": [
-    "Web/CSS/content"
+    "Web/CSS/content#alternative_text"
   ],
   "alternative-style-sheets": [
     "Web/CSS/Alternative_style_sheets"

--- a/mdnDocsOverrides.json
+++ b/mdnDocsOverrides.json
@@ -20,7 +20,7 @@
     "Web/CSS/sign"
   ],
   "absolute-positioning": [
-    "Web/CSS/position"
+    "Web/CSS/position#absolute"
   ],
   "accelerometer": [
     "Web/API/Accelerometer"

--- a/mdnDocsOverrides.json
+++ b/mdnDocsOverrides.json
@@ -28,9 +28,7 @@
   "accent-color": [
     "Web/CSS/accent-color"
   ],
-  "active-view-transition": [
-    "Web/CSS/::view-transition"
-  ],
+  "active-view-transition": [],
   "address": [
     "Web/HTML/Element/address"
   ],

--- a/mdnDocsOverrides.json
+++ b/mdnDocsOverrides.json
@@ -180,9 +180,7 @@
   "audio": [
     "Web/HTML/Element/audio"
   ],
-  "audio-session": [
-    "Web/API/Navigator"
-  ],
+  "audio-session": [],
   "audio-video-tracks": [
     "Web/API/HTMLMediaElement/audioTracks",
     "Web/API/HTMLMediaElement/videoTracks"

--- a/mdnDocsOverrides.json
+++ b/mdnDocsOverrides.json
@@ -33,7 +33,9 @@
     "Web/HTML/Element/address"
   ],
   "alerts": [
-    "Web/API/Window/alert"
+    "Web/API/Window/alert",
+    "Web/API/Window/confirm",
+    "Web/API/Window/prompt"
   ],
   "align-content-block": [
     "Web/CSS/align-content"


### PR DESCRIPTION
Added MDN links for the features starting with the letter "a". It'll be good to proof-read as some of the mappings are not obvious. 

For example, there is no dedicated page for absolute positioning on the MDN page, but one can refer the [Position](https://developer.mozilla.org/en-US/docs/Web/CSS/position) page, and navigate to the "absolute" values using the [link](https://developer.mozilla.org/en-US/docs/Web/CSS/position#absolute).

However, there are no examples in the doc that links to the URL hashes, hence, refrained from adding them. Let me know if this is what you expect. If yes then will add for rest of the features.