### PR TITLE
Add dist link

### DIFF
--- a/site/_includes/feature_full.njk
+++ b/site/_includes/feature_full.njk
@@ -28,6 +28,7 @@
     <a href="https://wpt.fyi/results/?q=feature%3A{{ feature.id }}">View web-platform-tests results for this feature</a>
     -
     <a href="https://github.com/web-platform-dx/web-features/blob/main/features/{{ feature.id }}.yml">View the feature source file</a>
+    <a href="https://github.com/web-platform-dx/web-features/blob/main/features/{{ feature.id }}.yml.dist">(dist)</a>
     -
     <a href="https://github.com/web-platform-dx/web-features/edit/main/features/{{ feature.id }}.yml">Edit the feature</a>
     -


### PR DESCRIPTION
I often want to look at the dist file to see what has been computed from BCD. Can we add a link?