### PR TITLE
[Timeline] Escape quotes in names for injection in JSON-like object

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -246,6 +246,10 @@ export default function (eleventyConfig) {
     return name.replace(/</g, "&lt;").replace(/>/g, "&gt;");
   });
 
+  eleventyConfig.addShortcode("escapeJSON", function (name) {
+    return name.replace(/"/g, "\\\"");
+  });
+
   eleventyConfig.addShortcode("baselineDate", function (dateStr) {
     const isBefore = dateStr.startsWith("≤");
     if (isBefore) {

--- a/site/timeline.njk
+++ b/site/timeline.njk
@@ -14,7 +14,7 @@ layout: layout.njk
       {% if feature.status.baseline_low_date %}
         {
           feature: "{{ feature.id }}",
-          name: "{% prettyFeatureName feature.name %}",
+          name: "{% escapeJSON feature.name %}",
           baseline_low_date: "{{ feature.status.baseline_low_date }}"
         },
       {% endif %}


### PR DESCRIPTION
The timeline page is currently broken because some features now have double quotes in their names, which must be escaped for integration in the JS script of the page.