### PR TITLE
Investigate use of web-features (likely) v3.0.0 schema

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,17 +1,18 @@
 import { EleventyHtmlBasePlugin } from "@11ty/eleventy";
 import feedPlugin from "@11ty/eleventy-plugin-rss";
-import YAML from 'yaml';
-import { browsers, features, groups } from "web-features";
+import mdnInventory from "@ddbeck/mdn-content-inventory";
 import bcd from "@mdn/browser-compat-data" with { type: "json" };
 import specs from "browser-specs" with { type: "json" };
-import mdnInventory from "@ddbeck/mdn-content-inventory";
+import { browsers, groups } from "web-features";
+import YAML from 'yaml';
+import interop from "./additional-data/interop.json" with { type: "json" };
 import mdnDocsOverrides from "./additional-data/mdn-docs.json" with { type: "json" };
-import standardPositions from "./additional-data/standard-positions.json" with { type: "json" };
 import originTrials from "./additional-data/origin-trials.json" with { type: "json" };
+import standardPositions from "./additional-data/standard-positions.json" with { type: "json" };
 import stateOfSurveys from "./additional-data/state-of-surveys.json" with { type: "json" };
 import useCounters from "./additional-data/use-counters.json" with { type: "json" };
-import interop from "./additional-data/interop.json" with { type: "json" };
 import wpt from "./additional-data/wpt.json" with { type: "json" };
+import { features } from "./features.js";
 
 // Number of months after Baseline low that Baseline high happens.
 // Keep in sync with definition at:

--- a/additional-data/scripts/check-docs.js
+++ b/additional-data/scripts/check-docs.js
@@ -4,11 +4,11 @@
 // This script does not map features to MDN URLs on its own. Mapping MDN URLs
 // is done manually.
 
-import { features } from "web-features";
 import bcd from "@mdn/browser-compat-data" with { type: "json" };
 import * as fs from "fs/promises";
-import mdnDocsOverrides from "../mdn-docs.json" with { type: "json" };
 import path from "path";
+import { features } from "../../features.js";
+import mdnDocsOverrides from "../mdn-docs.json" with { type: "json" };
 
 const FILE = path.join(import.meta.dirname, "../mdn-docs.json");
 

--- a/additional-data/scripts/update-origin-trials.js
+++ b/additional-data/scripts/update-origin-trials.js
@@ -24,10 +24,10 @@
 // For Edge, see https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials
 // For Firefox, see https://wiki.mozilla.org/Origin_Trials
 
-import { features } from "web-features";
 import fs from "fs/promises";
-import trials from "../origin-trials.json" with { type: "json" };
 import path from "path";
+import { features } from "../../features.js";
+import trials from "../origin-trials.json" with { type: "json" };
 
 const OUTPUT_FILE = path.join(import.meta.dirname, "../origin-trials.json");
 

--- a/additional-data/scripts/update-standard-positions.js
+++ b/additional-data/scripts/update-standard-positions.js
@@ -23,10 +23,10 @@
 // Always check the new position URLs added by the script (for mozilla only for now) to make sure they are correct.
 // Add "not" entries if any of the URLs are not relevant to a feature.
 
-import { features } from "web-features";
 import fs from "fs/promises";
-import positions from "../standard-positions.json" with { type: "json" };
 import path from "path";
+import { features } from "../../features.js";
+import positions from "../standard-positions.json" with { type: "json" };
 
 const OUTPUT_FILE = path.join(import.meta.dirname, "../standard-positions.json");
 const MOZILLA_DATA_FILE =

--- a/additional-data/scripts/update-use-counters.js
+++ b/additional-data/scripts/update-use-counters.js
@@ -10,10 +10,10 @@
 // }
 //
 
-import { features } from "web-features";
 import fs from "fs/promises";
-import useCounters from "../use-counters.json" with { type: "json" };
 import path from "path";
+import { features } from "../../features.js";
+import useCounters from "../use-counters.json" with { type: "json" };
 
 const OUTPUT_FILE = path.join(import.meta.dirname, "../use-counters.json");
 

--- a/check-groups.js
+++ b/check-groups.js
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { features } from "web-features";
+import { features } from './features';
 
 const FILE = 'site/_data/featureCatalog.yml';
 

--- a/features.js
+++ b/features.js
@@ -1,0 +1,10 @@
+import { features as rawFeatureData } from "web-features";
+
+export const features = new Proxy(rawFeatureData, {
+  get(target, property) {
+    if (target[property].kind !== "feature") {
+      console.trace(`\`${property}\` is a redirect, not an ordinary feature`);
+    }
+    return Reflect.get(...arguments)
+  }
+});

--- a/update-timeline-stats.js
+++ b/update-timeline-stats.js
@@ -10,9 +10,10 @@
  * uncertainties in stats.
  */
 
-import { features, browsers } from "web-features";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { browsers } from "web-features";
+import { features } from "./features.js";
 
 const OUTPUT_TIMELINE = path.join(import.meta.dirname, "site", "assets", "timeline-number.json");
 const OUTPUT_DURATIONS = path.join(import.meta.dirname, "site", "assets", "timeline-durations.json");


### PR DESCRIPTION
@captainbrosset I played around with consuming data built from https://github.com/web-platform-dx/web-features/pull/3000 and I'm leaving this here mostly to share some notes on what I learned when I tried to do that. I don't expect you'll merge this, in any form.

- There are lots of imports directly from `web-features` in lots of places, so there will be lots of places to handle redirects.

- There are only a few hard-coded references to features. Most of the time this is not a problem, since most features are stable. For the additional data scripts, I suspect that you'll want to warn on simple moves and throw on splits (since the latter requires some decision making).

- `.eleventy.js` code modifies `features` data directly (as opposed to, for example, wrapping `feature[id]` in an object with getters). Some of that modification won't be necessary (like wrapping spec URLs in arrays) thanks to https://github.com/web-platform-dx/web-features/pull/3184. But adding supplementary data this way is kinda painful in a world with redirects, since you need to look at the type of the feature data before modifying it.

- A possible model for the future would be to centralize the features data and always access there, so common data handling tasks (like appending extra data) can be done once and consistently. I've done it here as a proxy object, just as a demonstration.

- In the brief time I spent with this, I wasn't able to figure how to make Eleventy generate a page that redirects to another. I imagine you'll want links to (for example) https://web-platform-dx.github.io/web-features-explorer/features/numeric-seperators/ to not be broken.

- Likewise, I wasn't sure of the right way to handle feature splits. It'd be nice to have a disambiguation page, to link to multiple features, but I wasn't sure if the `feature.njk` template should have an `if` condition based on the feature's `kind` property or if there should be separate `ordinaryFeatures` and `splits` data objects, with distinct templates. This is mostly a question of style for you.