### PR TITLE
Redirect moved features

### DIFF
--- a/site/unordinary-feature.njk
+++ b/site/unordinary-feature.njk
@@ -15,10 +15,9 @@ eleventyComputed:
       <div class="header">
         <h1>This feature has moved</h1>
       </div>
-      <p>See
-        <a href="/features/{{ feature.redirect_target | slugify }}">{% prettyFeatureName allFeaturesAsObject[feature.redirect_target].name %}</a>
-        instead.
+      <p> You're being redirected to <a href="/features/{{ feature.redirect_target | slugify }}">{% prettyFeatureName allFeaturesAsObject[feature.redirect_target].name %}</a> instead.
       </p>
+      <meta http-equiv="refresh" content="3;url=/features/{{ feature.redirect_target | slugify }}" />
     {% elif feature.kind == "split" %}
       <div class="header">
         <h1>This feature has been split</h1>


### PR DESCRIPTION
This PR redirects from one feature to another, when its `kind` is `"moved"`.

This is a bit of a hack. The `<meta>` tag ought to be in the `<head>`, along with a `<link rel="canonical" href="…">`. But I didn't know how to append to the `<head>` in Eleventy and this does work.