### PR TITLE
Add feed subscription links to the home page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,6 +9,75 @@ import { getAllBCDKeys, stripLessThan, getBrowserVersionReleaseDate, getAugmente
 import { BROWSERS_BY_ENGINE, WEB_FEATURES_MAPPINGS_URL } from "./consts.js";
 import siteConfig from "./site.config.js";
 
+const inlineSvgCache = new Map();
+
+function resolveSvgPath(src) {
+  if (src.startsWith("http://") || src.startsWith("https://")) {
+    return src;
+  }
+
+  if (src.startsWith("/")) {
+    return new URL(`./site${src}`, import.meta.url);
+  }
+
+  return new URL(src, import.meta.url);
+}
+
+async function fetchSvg(src) {
+  const response = await fetch(src);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch SVG ${src}: ${response.status} ${response.statusText}`);
+  }
+
+  return response.text();
+}
+
+async function readSvg(src, svgPath) {
+  return typeof svgPath === "string"
+    ? fetchSvg(src)
+    : fs.readFile(svgPath, "utf8");
+}
+
+async function getSvgContent(src) {
+  const svgPath = resolveSvgPath(src);
+  const cacheKey = svgPath.toString();
+
+  if (!inlineSvgCache.has(cacheKey)) {
+    const svgContentPromise = (async () => {
+      try {
+        const svg = await readSvg(src, svgPath);
+
+        if (!svg.trimStart().startsWith("<svg")) {
+          throw new Error(`Expected ${src} to contain an SVG`);
+        }
+
+        return svg;
+      } catch (error) {
+        inlineSvgCache.delete(cacheKey);
+        throw error;
+      }
+    })();
+
+    inlineSvgCache.set(cacheKey, svgContentPromise);
+  }
+
+  return inlineSvgCache.get(cacheKey);
+}
+
+function addSvgAttributes(svg, attributes = {}) {
+  const renderedAttributes = Object.entries(attributes)
+    .filter(([, value]) => value != null && value !== "")
+    .map(([name, value]) => `${name}="${String(value).replaceAll('"', "&quot;")}"`)
+    .join(" ");
+
+  if (!renderedAttributes) {
+    return svg;
+  }
+
+  return svg.replace("<svg", `<svg ${renderedAttributes}`);
+}
+
 function augmentFeatureData(feature, webFeaturesMappingsData) {
   // Rename group and spec to group*s* and spec*s*, since they're always arrays.
   feature.groups = feature.group || [];
@@ -125,6 +194,16 @@ export default async function (eleventyConfig) {
   );
 
   eleventyConfig.addShortcode("nameAsHTML", nameAsHTML);
+
+  eleventyConfig.addNunjucksAsyncShortcode("inlineSvg", async function (src, className) {
+    const svg = await getSvgContent(src);
+
+    return addSvgAttributes(svg, {
+      class: className,
+      "aria-hidden": "true",
+      focusable: "false",
+    });
+  });
 
   eleventyConfig.addShortcode("escapeJSON", function (name) {
     return name.replace(/"/g, "\\\"");

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 docs
+.DS_Store

--- a/site/_includes/layout.njk
+++ b/site/_includes/layout.njk
@@ -12,6 +12,8 @@ siteTitle: Web platform features explorer
       <link rel="stylesheet" type="text/css" href="{{ stylesheet }}">
     {% endif %}
     <link href="/assets/favicon.png" rel="icon" sizes="64x64" type="image/png">
+    <link rel="alternate" type="application/atom+xml" title="Baseline newly available features" href="/newly-available.xml">
+    <link rel="alternate" type="application/atom+xml" title="Baseline widely available features" href="/widely-available.xml">
     <link rel="alternate" type="application/atom+xml" title="Web platform release notes" href="/release-notes.xml">
   </head>
   <body>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -500,6 +500,92 @@ main {
   margin: var(--margin) 0;
 }
 
+.release-notes {    
+  .feed-subscriptions {
+    background: none;
+    padding: 0;
+    margin-block: var(--margin);
+    margin-block-end: calc(var(--margin) * 2);
+    margin-inline: 0;
+
+    h2 {
+      margin-block-end: 0.75rem;
+      background-image: none;
+      padding-inline: 0;
+    }
+  }
+}
+
+.feed-subscriptions {
+  ul {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    column-width: auto;
+  }
+}
+
+@media (max-width: 48rem) {
+  .feed-subscriptions {
+    ul {
+      grid-template-columns: 1fr;
+    }
+  }
+}
+
+.release-notes {
+  .feed-subscriptions {
+    li {
+      margin: 0;
+      list-style: none;
+    }
+  }
+}
+
+.feed-badge {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  min-block-size: 4rem;
+  padding: 0.75rem;
+  color: var(--text);
+  text-decoration: none;
+  background: var(--bg, var(--background-alt));
+  border: 0.125rem solid var(--border, var(--baseline-limited-border));
+  border-radius: 0.5rem;
+}
+
+.feed-badge:hover strong {
+  text-decoration: underline;
+}
+
+.feed-badge-icon {
+  flex: 0 0 2rem;
+  inline-size: 2rem;
+  block-size: 2rem;
+}
+
+.feed-badge {
+  strong,
+  span span {
+    display: block;
+  }
+
+  span span {
+    color: var(--sub-text);
+    font-size: 0.85rem;
+  }
+}
+
+.release-feed {
+  --bg: linear-gradient(
+    to right,
+    var(--baseline-low-bg),
+    var(--baseline-high-bg)
+  );
+  --border: var(--baseline-high-border);
+}
+
 /* List of all release notes */
 
 .monthly-update-list {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -525,14 +525,6 @@ main {
   }
 }
 
-@media (max-width: 48rem) {
-  .feed-subscriptions {
-    ul {
-      grid-template-columns: 1fr;
-    }
-  }
-}
-
 .release-notes {
   .feed-subscriptions {
     li {
@@ -543,16 +535,30 @@ main {
 }
 
 .feed-badge {
-  display: flex;
-  gap: 0.75rem;
   align-items: center;
-  min-block-size: 4rem;
-  padding: 0.75rem;
-  color: var(--text);
-  text-decoration: none;
   background: var(--bg, var(--background-alt));
   border: 0.125rem solid var(--border, var(--baseline-limited-border));
   border-radius: 0.5rem;
+  color: var(--text);
+  display: flex;
+  gap: 0.75rem;
+  min-block-size: 4rem;
+  padding: 0.75rem;
+  text-decoration: none;
+}
+
+@media (width < 48rem) {
+  .feed-subscriptions {
+    ul {
+      grid-template-columns: 1fr;
+    }
+  }
+}
+
+@media (width >= 48rem) {
+  .feed-badge {
+    block-size: 100%;
+  }
 }
 
 .feed-badge:hover strong {

--- a/site/index.njk
+++ b/site/index.njk
@@ -12,17 +12,7 @@ layout: layout.njk
     <ul>
       <li>
         <a class="feed-badge baseline-low" href="./newly-available.xml">
-          <svg class="feed-badge-icon" aria-hidden="true" focusable="false" viewBox="0 0 540 300" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M150 0L180 30L150 60L120 30L150 0Z" fill="#A8C7FA"/>
-            <path d="M210 60L240 90L210 120L180 90L210 60Z" fill="#A8C7FA"/>
-            <path d="M450 60L480 90L450 120L420 90L450 60Z" fill="#A8C7FA"/>
-            <path d="M510 120L540 150L510 180L480 150L510 120Z" fill="#A8C7FA"/>
-            <path d="M450 180L480 210L450 240L420 210L450 180Z" fill="#A8C7FA"/>
-            <path d="M390 240L420 270L390 300L360 270L390 240Z" fill="#A8C7FA"/>
-            <path d="M330 180L360 210L330 240L300 210L330 180Z" fill="#A8C7FA"/>
-            <path d="M90 60L120 90L90 120L60 90L90 60Z" fill="#A8C7FA"/>
-            <path d="M390 0L420 30L150 300L0 150L30 120L150 240L390 0Z" fill="#1B6EF3"/>
-          </svg>
+          {% inlineSvg "https://web-platform-dx.github.io/assets/img/baseline-newly-icon.svg", "feed-badge-icon" %}
           <span>
             <strong>Newly available</strong>
             <span>Baseline updates</span>
@@ -31,11 +21,7 @@ layout: layout.njk
       </li>
       <li>
         <a class="feed-badge baseline-high" href="./widely-available.xml">
-          <svg class="feed-badge-icon" aria-hidden="true" focusable="false" viewBox="0 0 540 300" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M420 30L390 60L480 150L390 240L330 180L300 210L390 300L540 150L420 30Z" fill="#C4EED0"/>
-            <path d="M150 0L30 120L60 150L150 60L210 120L240 90L150 0Z" fill="#C4EED0"/>
-            <path d="M390 0L420 30L150 300L0 150L30 120L150 240L390 0Z" fill="#1EA446"/>
-          </svg>
+          {% inlineSvg "https://web-platform-dx.github.io/assets/img/baseline-widely-icon.svg", "feed-badge-icon" %}
           <span>
             <strong>Widely available</strong>
             <span>Baseline updates</span>

--- a/site/index.njk
+++ b/site/index.njk
@@ -8,7 +8,7 @@ layout: layout.njk
   <p>Use the Web platform features explorer to discover new features and APIs and stay up-to-date with changes.</p>
 
   <section class="feed-subscriptions" aria-labelledby="feed-subscriptions-heading">
-    <h2 id="feed-subscriptions-heading">Subscribe to updates</h2>
+    <h2 id="feed-subscriptions-heading">Subscribe to RSS feeds</h2>
     <ul>
       <li>
         <a class="feed-badge baseline-low" href="./newly-available.xml">

--- a/site/index.njk
+++ b/site/index.njk
@@ -14,8 +14,8 @@ layout: layout.njk
         <a class="feed-badge baseline-low" href="./newly-available.xml">
           {% inlineSvg "https://web-platform-dx.github.io/assets/img/baseline-newly-icon.svg", "feed-badge-icon" %}
           <span>
-            <strong>Newly available</strong>
-            <span>Baseline updates</span>
+            <strong>Baseline newly available</strong>
+            <span>Get newly available feature updates via RSS</span>
           </span>
         </a>
       </li>
@@ -23,8 +23,8 @@ layout: layout.njk
         <a class="feed-badge baseline-high" href="./widely-available.xml">
           {% inlineSvg "https://web-platform-dx.github.io/assets/img/baseline-widely-icon.svg", "feed-badge-icon" %}
           <span>
-            <strong>Widely available</strong>
-            <span>Baseline updates</span>
+            <strong>Baseline widely available</strong>
+            <span>Get widely available feature updates via RSS</span>
           </span>
         </a>
       </li>
@@ -43,8 +43,8 @@ layout: layout.njk
             <path d="m625 4l-209.7 323.7c-0.5 0.6-1.1 1.2-2 1.7l-53.3-81.9 158-243.7c0.9-1.4 3.2-2.8 6.1-2.8h98.7c2.7 0 3 2 2.2 3z" fill="url(#feed-badge-logo-gradient)"/>
           </svg>
           <span>
-            <strong>Monthly release notes</strong>
-            <span>All platform updates</span>
+            <strong>Monthly updates</strong>
+            <span>Get monthly Baseline and browser updates via RSS</span>
           </span>
         </a>
       </li>

--- a/site/index.njk
+++ b/site/index.njk
@@ -5,10 +5,68 @@ layout: layout.njk
 
 <main class="home release-notes">
   <h1>Stay up-to-date with the web platform</h1>
-  <p>Use the Web platform features explorer to discover new features and APIs and stay up-to-date with changes.</h1>
+  <p>Use the Web platform features explorer to discover new features and APIs and stay up-to-date with changes.</p>
+
+  <section class="feed-subscriptions" aria-labelledby="feed-subscriptions-heading">
+    <h2 id="feed-subscriptions-heading">Subscribe to updates</h2>
+    <ul>
+      <li>
+        <a class="feed-badge baseline-low" href="./newly-available.xml">
+          <svg class="feed-badge-icon" aria-hidden="true" focusable="false" viewBox="0 0 540 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M150 0L180 30L150 60L120 30L150 0Z" fill="#A8C7FA"/>
+            <path d="M210 60L240 90L210 120L180 90L210 60Z" fill="#A8C7FA"/>
+            <path d="M450 60L480 90L450 120L420 90L450 60Z" fill="#A8C7FA"/>
+            <path d="M510 120L540 150L510 180L480 150L510 120Z" fill="#A8C7FA"/>
+            <path d="M450 180L480 210L450 240L420 210L450 180Z" fill="#A8C7FA"/>
+            <path d="M390 240L420 270L390 300L360 270L390 240Z" fill="#A8C7FA"/>
+            <path d="M330 180L360 210L330 240L300 210L330 180Z" fill="#A8C7FA"/>
+            <path d="M90 60L120 90L90 120L60 90L90 60Z" fill="#A8C7FA"/>
+            <path d="M390 0L420 30L150 300L0 150L30 120L150 240L390 0Z" fill="#1B6EF3"/>
+          </svg>
+          <span>
+            <strong>Newly available</strong>
+            <span>Baseline updates</span>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a class="feed-badge baseline-high" href="./widely-available.xml">
+          <svg class="feed-badge-icon" aria-hidden="true" focusable="false" viewBox="0 0 540 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M420 30L390 60L480 150L390 240L330 180L300 210L390 300L540 150L420 30Z" fill="#C4EED0"/>
+            <path d="M150 0L30 120L60 150L150 60L210 120L240 90L150 0Z" fill="#C4EED0"/>
+            <path d="M390 0L420 30L150 300L0 150L30 120L150 240L390 0Z" fill="#1EA446"/>
+          </svg>
+          <span>
+            <strong>Widely available</strong>
+            <span>Baseline updates</span>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a class="feed-badge release-feed" href="./release-notes.xml">
+          <svg class="feed-badge-icon" aria-hidden="true" focusable="false" viewBox="0 0 628 332" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="feed-badge-logo-gradient" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,328.4,-265.388,0,360.04,1)">
+                <stop stop-color="#95e3ab"/>
+                <stop offset="1" stop-color="#0e6528"/>
+              </linearGradient>
+            </defs>
+            <path d="m279.6 330.3h-103.3c-2.6 0-5-1.6-6-3.2l-168.9-260.6c-1.5-2.4 0.2-5.1 2.7-5.1h96.6c3-0.1 5.3 0.9 6.7 3.1l118.6 183.1z" fill="black"/>
+            <path d="m360 206.2l-53.6-82.7 38.5-59.4c0.9-1.2 3.4-2.7 5.6-2.7h99.2c2.7 0 2.9 2 2 3.3z" fill="black"/>
+            <path d="m625 4l-209.7 323.7c-1 1.2-2.6 2.6-5.8 2.6h-103.1l-132.1-203.7c-1-1.6-0.3-3.5 1.8-3.5h98.9c2.3 0 5.2 1.3 6.3 3.1l78.7 121.4 158-243.8c0.9-1.4 3.2-2.8 6.1-2.8h98.7c2.7 0 3 2 2.2 3z" fill="#1EA446"/>
+            <path d="m625 4l-209.7 323.7c-0.5 0.6-1.1 1.2-2 1.7l-53.3-81.9 158-243.7c0.9-1.4 3.2-2.8 6.1-2.8h98.7c2.7 0 3 2 2.2 3z" fill="url(#feed-badge-logo-gradient)"/>
+          </svg>
+          <span>
+            <strong>Monthly release notes</strong>
+            <span>All platform updates</span>
+          </span>
+        </a>
+      </li>
+    </ul>
+  </section>
 
   <section class="baseline-low">
-    <h2>Newly available across browsers (<a href="./newly-available.xml">RSS feed</a>)</h2>
+    <h2>Newly available across browsers</h2>
     <ul>
       {% for feature in latest.latestBaselineLow %}
         <li>
@@ -20,7 +78,7 @@ layout: layout.njk
   </section>
 
   <section class="baseline-high">
-    <h2>Now widely available across browsers (<a href="./widely-available.xml">RSS feed</a>)</h2>
+    <h2>Now widely available across browsers</h2>
     <ul>
       {% for feature in latest.latestBaselineHigh %}
         <li>

--- a/site/monthly-updates-feed.njk
+++ b/site/monthly-updates-feed.njk
@@ -17,10 +17,10 @@
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.url }}">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.subtitle }}</subtitle>
-  <link href="https://web-platform-dx.github.io/web-features-explorer/release-notes.xml" rel="self"/>
+  <link href="{{ metadata.url + 'release-notes.xml' }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
   <updated>{{ collections.perMonth | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
-  <id>{{ metadata.url }}</id>
+  <id>{{ metadata.url + 'release-notes.xml' }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>
   </author>

--- a/site/newly-available-feed.njk
+++ b/site/newly-available-feed.njk
@@ -17,10 +17,10 @@
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.url }}">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.subtitle }}</subtitle>
-  <link href="https://web-platform-dx.github.io/web-features-explorer/newly-available.xml" rel="self"/>
+  <link href="{{ metadata.url + 'newly-available.xml' }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
   <updated>{{ newlyAvailableFeatures[0].baselineLowDateAsObject | dateToRfc3339 }}</updated>
-  <id>{{ metadata.url }}</id>
+  <id>{{ metadata.url + 'newly-available.xml' }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>
   </author>

--- a/site/widely-available-feed.njk
+++ b/site/widely-available-feed.njk
@@ -17,10 +17,10 @@
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.url }}">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.subtitle }}</subtitle>
-  <link href="https://web-platform-dx.github.io/web-features-explorer/widely-available.xml" rel="self"/>
+  <link href="{{ metadata.url + 'widely-available.xml' }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
   <updated>{{ widelyAvailableFeatures[0].baselineHighDateAsObject | dateToRfc3339 }}</updated>
-  <id>{{ metadata.url }}</id>
+  <id>{{ metadata.url + 'widely-available.xml' }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>
   </author>


### PR DESCRIPTION
## Summary

Adds clearer RSS feed discovery for issue #6 by surfacing the existing Atom feeds directly on the landing page.

## Changes

- Adds a “Subscribe to updates” badge row to the home page.
- Links to the existing feeds:
  - Baseline newly available: `/newly-available.xml`
  - Baseline widely available: `/widely-available.xml`
  - Monthly release notes: `/release-notes.xml`
- Inlines the badge SVG icons in the home page markup.
- Adds all three feeds as `<link rel="alternate" type="application/atom+xml">` entries.
- Updates feed-level Atom IDs to use each feed’s own URL.
- Adds `.DS_Store` to `.gitignore`.

## Validation

- Ran `npm run build`
- Ran `xmllint --noout docs/newly-available.xml docs/widely-available.xml docs/release-notes.xml`
- Checked the badge layout at desktop and mobile widths.

Fix #6 